### PR TITLE
update brush data on replot

### DIFF
--- a/@big_plot/renderData.m
+++ b/@big_plot/renderData.m
@@ -393,10 +393,20 @@ for iG = find(is_valid_group_mask)
     if size(x_r,2) == 1
         for iChan = 1:length(local_h)
             set(local_h(iChan), 'XData', x_r, 'YData', y_r(:,iChan));
+            try
+                brush_data = get(local_h(iChan), 'BrushData');
+                set(local_h(iChan), 'BrushData', brush_data);
+            catch
+            end
         end
     else
         for iChan = 1:length(local_h)
             set(local_h(iChan), 'XData', x_r(:,iChan), 'YData', y_r(:,iChan));
+            try
+                brush_data = get(local_h(iChan), 'BrushData');
+                set(local_h(iChan), 'BrushData', brush_data);
+            catch
+            end
         end
     end
     


### PR DESCRIPTION
Resets line object BrushData property on replot so that brushed data is correctly shown during zooming. Otherwise brushed data is not shown when zooming.

Note: I realize that the brushed data points will not directly correspond to the raw data if any downsampling was used. Nonetheless, their time ranges can be extracted and used to apply the selection to the raw data, so being able to brush data points is still useful.